### PR TITLE
Fix settings to grammar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "log.h": "c",
+        "sds.h": "c",
+        "stb_ds.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "files.associations": {
-        "log.h": "c",
-        "sds.h": "c",
-        "stb_ds.h": "c"
-    }
-}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,7 +24,7 @@ cc_library(
 	name = "env_args",
 	srcs = ["lib/env_args.cpp"],
 	hdrs = ["lib/env_args.h"],
-	copts = ["-std=c++20", "-fno-rtti"],
+	copts = ["-std=c++2a", "-fno-rtti"],
 	deps = select({
         "@bazel_tools//src/conditions:darwin_x86_64": ["@darwin-amd64//:llvm"],
         "@bazel_tools//src/conditions:linux_aarch64": ["@linux-aarch64//:llvm"],

--- a/src/kapuc/lex.c
+++ b/src/kapuc/lex.c
@@ -39,9 +39,6 @@
     TOK_SYMBOL(pToks, word, "else", ELSE, p, 4)                                \
     TOK_SYMBOL(pToks, word, "let", LET, p, 3)                                  \
     TOK_SYMBOL(pToks, word, "const", CONST, p, 5)                              \
-    TOK_SYMBOL(pToks, word, "if", IF, p, 2)                                    \
-    TOK_SYMBOL(pToks, word, "else", ELSE, p, 4)                                \
-    TOK_SYMBOL(pToks, word, "elif", ELIF, p, 4)                                \
     TOK_SYMBOL(pToks, word, "true", TRUE, p, 4)                                \
     TOK_SYMBOL(pToks, word, "false", FALSE, p, 5)
 

--- a/src/kapuc/main.c
+++ b/src/kapuc/main.c
@@ -164,13 +164,15 @@ main(const int argc, char** argv)
     }
     log_debug("lexing finished: got %d tokens", arrlen(tokens));
 #ifdef SUPER_AGGRESSIVE_DEBUG
-    for (int i = 0; i < arrlen(tokens); i++)
-        log_debug("tokens %d is %d: %s (pos: %ld-%ld)",
+    for (int i = 0; i < arrlen(tokens); i++){
+      log_debug("tokens %d is %d: %s (pos: %ld-%ld)",
                   i + 1,
                   tokens[i].t,
                   tokens[i].s,
                   tokens[i].start + 1,
                   tokens[i].end + 1);
+    }
+        
 #endif
     if (!no_parse) {
         log_debug("parsing started");

--- a/src/kapuc/main.c
+++ b/src/kapuc/main.c
@@ -164,15 +164,15 @@ main(const int argc, char** argv)
     }
     log_debug("lexing finished: got %d tokens", arrlen(tokens));
 #ifdef SUPER_AGGRESSIVE_DEBUG
-    for (int i = 0; i < arrlen(tokens); i++){
-      log_debug("tokens %d is %d: %s (pos: %ld-%ld)",
+    for (int i = 0; i < arrlen(tokens); i++) {
+        log_debug("tokens %d is %d: %s (pos: %ld-%ld)",
                   i + 1,
                   tokens[i].t,
                   tokens[i].s,
                   tokens[i].start + 1,
                   tokens[i].end + 1);
     }
-        
+
 #endif
     if (!no_parse) {
         log_debug("parsing started");


### PR DESCRIPTION
Yeh, my brain can't comprehend this

~~- merge grammar branch~~
- fix c++20 to c++2x
TODO for grammar branch (not complete?):
- [ ] update the lexer/tokenizer
- [ ] finish parser
- [ ] add control flow to grammar
- [ ] add struct and enum

Full grammar list (copied from issue grammar and parser) (this is just the ebnf grammar):
- [x] variables (mutable, immutable (default), type infer)
- types (default types, enumerator, type parameters ~~, overload?~~) (https://github.com/microsoft/TypeScript/issues/16392 this is a great example I think but too dynamic for static type language, type coercion could be useful for pointer but enum exists?)
  - [x] default types
modifier
    - [x] `&t` (pointer to t)
      - [x] use *t to de-reference t

      - [x] You can arithmetic with pointers
    - [x] `t<x, y>` (t with parameter x, y) (parameter of types should be type themselves)
    - [x] `t::a` (enumerator t of type/path a)
      - enumerator types can have parameter/value like `t::b(c<d>)` or something like that
- [x] functions (function, function pointers, coffee attributes (`@safe` `@unsafe`, ...), variadic parameters)
- [x] blocks 
  - ~~[ ] (`@safe @unsafe` blocks, `@_internal` blocks)~~ we could just analyze type?
  - control-flow
    - [ ] if-else
    - [ ] for/while loop (while loop could be internally replace to for loop for some optimization without much work?)
    - [ ] coffee parameter for block
    - [ ] switch
       - case arm is block so we could also do parameter (we could cold the arm like rust too??)
- [x] coffee
- [x] importing (`import aa::bb::cc::{d, e};`) and the `::` syntax for path